### PR TITLE
feat: improve hashtag generation and add member name to hashtags

### DIFF
--- a/.github/workflows/check-gh-pages-push.yml
+++ b/.github/workflows/check-gh-pages-push.yml
@@ -1,0 +1,21 @@
+name: Check gh-pages Push
+
+on:
+  push:
+    branches:
+      - gh-pages
+
+jobs:
+  check-pusher:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if pusher is a developer
+        # This workflow allows pushes only from the official GitHub Actions bot,
+        # which is used by the deployment action. All other pushes from developers
+        # will be marked as a failure.
+        if: github.actor != 'github-actions[bot]'
+        run: |
+          echo "ERROR: Direct pushes to the gh-pages branch are not allowed."
+          echo "Please submit changes to the main branch."
+          echo "The site will be deployed automatically from there."
+          exit 1

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -79,7 +79,7 @@ describe('Idol Post Generator', () => {
     fireEvent.click(screen.getByLabelText('冨田 菜々風'));
 
     // 3. オプションを変更
-    fireEvent.click(screen.getByLabelText('メンバー名をハッシュタグにする'));
+    fireEvent.click(screen.getByLabelText('ハッシュタグにメンバー名を追加する'));
     fireEvent.click(screen.getByLabelText('敬称とXアカウントを逆にする'));
     fireEvent.change(screen.getByLabelText('敬称'), {
       target: { value: 'ちゃん' },
@@ -102,9 +102,9 @@ describe('Idol Post Generator', () => {
       '特別公演',
       '@ 武道館',
       '',
-      '#冨田菜々風 ちゃん (@tomita_nanaka)',
+      '冨田 菜々風ちゃん (@tomita_nanaka)',
       '',
-      '#ノイミー #ノイミー_カメコ #かわいい #超絶イケメン',
+      '#ノイミー #ノイミー_カメコ #かわいい #超絶イケメン #冨田菜々風',
     ].join('\n');
 
     expect(generatedTextArea.value).toBe(expectedText);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ interface FormData {
   selectedMembers: string[];
   honorific: string;
   hashtags: string;
-  membersAsHashtags: boolean;
+  addMemberNameToHashtag: boolean;
   reverseAccountHonorific: boolean;
   useParenthesesForAccount: boolean;
 }
@@ -27,7 +27,7 @@ const getInitialState = (): FormData => {
     selectedMembers: [],
     honorific: 'さん',
     hashtags: '',
-    membersAsHashtags: false,
+    addMemberNameToHashtag: false,
     reverseAccountHonorific: false,
     useParenthesesForAccount: true,
   };
@@ -104,7 +104,7 @@ function App() {
       selectedMembers,
       honorific,
       hashtags,
-      membersAsHashtags,
+      addMemberNameToHashtag,
       reverseAccountHonorific,
       useParenthesesForAccount,
     } = formData;
@@ -132,7 +132,10 @@ function App() {
         .filter((tag) => tag)
         .map((tag) => `#${tag}`)
         .join(' ');
-      return [groupHashtag, groupCamekoHashtag, userHashtags]
+      const memberHashtags = addMemberNameToHashtag
+        ? selectedMembers.map((name) => `#${name.replace(/\s/g, '')}`).join(' ')
+        : '';
+      return [groupHashtag, groupCamekoHashtag, userHashtags, memberHashtags]
         .filter(Boolean)
         .join(' ');
     };
@@ -144,15 +147,9 @@ function App() {
           const account = useParenthesesForAccount
             ? `(@${memberInfo.account})`
             : `@${memberInfo.account}`;
-          let namePart = memberInfo.name;
-          if (membersAsHashtags) {
-            namePart = `#${memberInfo.name.replace(/\s/g, '')}`;
-          }
+          const namePart = memberInfo.name;
 
           if (reverseAccountHonorific) {
-            if (membersAsHashtags) {
-              return `${namePart} ${honorific} ${account}`;
-            }
             return `${namePart}${honorific} ${account}`;
           }
           return `${namePart} ${account}${honorific}`;
@@ -308,12 +305,12 @@ function App() {
             <input
               className="form-check-input"
               type="checkbox"
-              id="membersAsHashtags"
-              checked={formData.membersAsHashtags}
+              id="addMemberNameToHashtag"
+              checked={formData.addMemberNameToHashtag}
               onChange={handleChange}
             />
-            <label className="form-check-label" htmlFor="membersAsHashtags">
-              メンバー名をハッシュタグにする
+            <label className="form-check-label" htmlFor="addMemberNameToHashtag">
+              ハッシュタグにメンバー名を追加する
             </label>
           </div>
           <div className="form-check mb-3">


### PR DESCRIPTION
- Renamed  to  for better clarity.
- Modified the hashtag generation logic to add member names as separate hashtags instead of replacing the member name in the post.
- Updated the corresponding test case in .
- Added a new GitHub Actions workflow .