### PR TITLE
refine: remove group name from hashtags

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -53,7 +53,7 @@ describe('Idol Post Generator', () => {
       '大谷 映美里 (@otani_emiri)さん',
       '佐々木 舞香 (@sasaki_maika)さん',
       '',
-      '#イコラブ #イコラブ_カメコ',
+      '#イコラブ_カメコ',
     ].join('\n');
 
     expect(generatedTextArea.value).toBe(expectedText);
@@ -87,8 +87,10 @@ describe('Idol Post Generator', () => {
 
     // 4. カスタムハッシュタグを追加
     fireEvent.change(
-      screen.getByLabelText('追加ハッシュタグ (スペースかカンマ区切り)'),
-      { target: { value: 'かわいい 超絶イケメン' } },
+      screen.getByLabelText('追加ハッシュタグ (スペースかカンマ区切り)')
+      , {
+        target: { value: 'かわいい 超絶イケメン' },
+      },
     );
 
     // 5. 生成されたテキストエリアを取得
@@ -104,7 +106,7 @@ describe('Idol Post Generator', () => {
       '',
       '冨田 菜々風ちゃん (@tomita_nanaka)',
       '',
-      '#ノイミー #ノイミー_カメコ #かわいい #超絶イケメン #冨田菜々風',
+      '#ノイミー_カメコ #かわいい #超絶イケメン #冨田菜々風',
     ].join('\n');
 
     expect(generatedTextArea.value).toBe(expectedText);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,7 +125,6 @@ function App() {
     };
 
     const createHashtags = (tags: string): string => {
-      const groupHashtag = group ? `#${group}` : '';
       const groupCamekoHashtag = group ? `#${group}_カメコ` : '';
       const userHashtags = tags
         .split(/[,\s]+/)
@@ -135,7 +134,7 @@ function App() {
       const memberHashtags = addMemberNameToHashtag
         ? selectedMembers.map((name) => `#${name.replace(/\s/g, '')}`).join(' ')
         : '';
-      return [groupHashtag, groupCamekoHashtag, userHashtags, memberHashtags]
+      return [groupCamekoHashtag, userHashtags, memberHashtags]
         .filter(Boolean)
         .join(' ');
     };


### PR DESCRIPTION
Removes the group name hashtag (e.g., #イコラブ) from the generated post, while keeping the group's "cameko" hashtag (e.g., #イコラブ_カメコ). This provides a cleaner and more focused set of hashtags.

#2 