### PR TITLE
feat(hashtag): add member-specific hashtags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,10 +140,24 @@ function App() {
         .filter((tag) => tag)
         .map((tag) => `#${tag}`)
         .join(' ');
-      const memberHashtags = addMemberNameToHashtag
-        ? selectedMembers.map((name) => `#${name.replace(/\s/g, '')}`).join(' ')
-        : '';
-      return [groupBasedHashtag, userHashtags, memberHashtags]
+      const memberNameHashtags = addMemberNameToHashtag
+        ? selectedMembers.map((name) => `#${name.replace(/\s/g, '')}`)
+        : [];
+
+      const specificMemberHashtags = selectedMembers
+        .map((name) => {
+          const memberInfo = groups[group].members.find((m) => m.name === name);
+          return memberInfo?.specificHashtag
+            ? `#${memberInfo.specificHashtag}`
+            : null;
+        })
+        .filter((tag): tag is string => tag !== null);
+
+      const allMemberHashtags = Array.from(
+        new Set([...specificMemberHashtags, ...memberNameHashtags]),
+      ).join(' ');
+
+      return [groupBasedHashtag, userHashtags, allMemberHashtags]
         .filter(Boolean)
         .join(' ');
     };

--- a/src/data/groups.ts
+++ b/src/data/groups.ts
@@ -2,6 +2,7 @@ interface Member {
   name: string;
   account: string;
   url: string;
+  specificHashtag?: string;
 }
 
 interface GroupInfo {


### PR DESCRIPTION
- Add a `specificHashtag` field to the `Member` interface to allow for member-specific hashtags.
- Update the hashtag generation logic to include these specific hashtags, preventing duplicates.
- This enables the use of official nicknames or unique hashtags for members .